### PR TITLE
删除子评论之间的逗号

### DIFF
--- a/src/disqus.js
+++ b/src/disqus.js
@@ -501,10 +501,10 @@ function DisqusJS(config) {
                     }
                 })();
 
-                html += children.map((comment) => {
+                children.map((comment) => {
                     comment = processData(comment);
                     comment.nesting = nesting + 1;
-                    return `<li data-id="comment-${comment.comment.id}">${renderPostItem(comment.comment)}${childrenComments(comment)}</li>`;
+                    html += `<li data-id="comment-${comment.comment.id}">${renderPostItem(comment.comment)}${childrenComments(comment)}</li>`;
                 });
 
                 html += '</ul>';


### PR DESCRIPTION
## 问题

在两个子评论之间出现了一个莫名其妙的 `,`

![image](https://user-images.githubusercontent.com/4951333/47337239-b0eca400-d6c5-11e8-9822-c086516ce251.png)

## 原因

字符串加上了一个数组，然后数组之间会以 `,` 隔开。