### PR TITLE
refactor: remove inappropriate styles

### DIFF
--- a/src/disqusjs.css
+++ b/src/disqusjs.css
@@ -1,9 +1,6 @@
 #dsqjs * {
     margin: 0;
     padding: 0;
-    font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 #dsqjs a {
@@ -165,11 +162,6 @@
     word-wrap: break-word;
     overflow: hidden;
     color: #2a2e2e
-}
-
-#dsqjs .dsqjs-post-body code,
-#dsqjs .dsqjs-post-body pre {
-    font-family: "SF Mono", "Segoe UI Mono", Consolas, "Roboto Mono", "Liberation Mono", Menlo, Courier, 'Courier New', monospace !important;
 }
 
 #dsqjs .dsqjs-post-body code {


### PR DESCRIPTION
1. Remove `-webkit-font-smoothing` and `-moz-osx-font-smoothing`
  See https://github.com/woocommerce/storefront/issues/698 and http://usabilitypost.com/2012/11/05/stop-fixing-font-smoothing/.
2. Remove `font-family`
  Almost every site uses its own `font-family` config and has to override DisqusJS's, thus providing default styles is useless for most people.
  PS: To provide better display quality, we should encourage site owners to use proper `font-family` config instead of defining it in our own apps.