### PR TITLE
Fix `replaceDisquscdn` and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ DisqusJS v1.2.6 开始支持检测是否存在 Disqus 实例，并在加载 Disq
 
 ## 调试、进阶使用 & 开发相关
 
-- ~~`a.disquscdn.com` 和 ~~`c.disquscdn.com` 解析到 Cloudflare 而不是 Fastly，可用性大大增强；`disqus.com` 和 `shortname.disqus.com` 仍然被墙；`disq.us` 解析到 Fastly 连通性较差，DisqusJS 通过解析获得了原链接。
+- ~~`a.disquscdn.com` 和~~ `c.disquscdn.com` 解析到 Cloudflare 而不是 Fastly，可用性大大增强；`disqus.com` 和 `shortname.disqus.com` 仍然被墙；`disq.us` 解析到 Fastly 连通性较差，DisqusJS 通过解析获得了原链接。
 - `a.disquscdn.com` 重新解析到 Fastly，可用性不如 `c.disquscdn.com`，DisqusJS 内部已增加替换 `a.disquscdn.com` 为 `c.disquscdn.com` 以改善速度。
 - DisqusJS 检测访客的 Disqus 可用性是通过检测 `disqus.com/favicon.ico` 和 `${disqusjs.config.shortname}.disqus.com/favicon.ico` 是否能正常加载，如果有一个加载出错或超时（2s）就判定 Disqus 不可用。
 - DisqusJS 在 localStorage 中持久化了 Disqus 连通性检查结果，key 为 `dsqjs_mode`，value 为 `disqus` 或者 `dsqjs`。需要调整 DisqusJS 的模式时可以直接操作 localStorage。

--- a/src/disqus.js
+++ b/src/disqus.js
@@ -536,7 +536,7 @@ function DisqusJS(config) {
                     el.innerHTML = msg;
                     const aTag = el.getElementsByTagName('a');
                     for (const i of aTag) {
-                        const link = decodeURIComponent(i.href.replaceAll('https://disq.us/url?url=', '')).replace(/(.*):.+cuid=.*/, '$1');
+                        const link = decodeURIComponent(i.href.replace(/https:\/\/disq\.us\/url\?url=/g, '')).replace(/(.*):.+cuid=.*/, '$1');
 
                         i.href = link;
                         i.innerHTML = link;
@@ -552,7 +552,7 @@ function DisqusJS(config) {
                  * @param {string} str - 字符串
                  * @return {string} - 替换后的字符串
                  */
-                const replaceDisquscdn = (str) => str.replaceAll('a.disquscdn.com', 'c.disquscdn.com');
+                const replaceDisquscdn = (str) => str.replace(/a\.disquscdn\.com/g, 'c.disquscdn.com');
 
                 const renderPostItem = (s) => {
                     let authorEl = '';

--- a/src/disqus.js
+++ b/src/disqus.js
@@ -28,7 +28,7 @@
 
 function DisqusJS(config) {
     ((window, document, localStorage, fetch, Promise) => {
-        // 封装一下基于 Object.asign 的方法
+        // 封装一下基于 Object.assign 的方法
         function _extends(...args) {
             _extends = Object.assign || function (target) {
                 for (const source of arguments) {
@@ -536,7 +536,7 @@ function DisqusJS(config) {
                     el.innerHTML = msg;
                     const aTag = el.getElementsByTagName('a');
                     for (const i of aTag) {
-                        const link = decodeURIComponent(i.href.replace(/https:\/\/disq.us\/url\?url=/g, '')).replace(/(.*):.+cuid=.*/, '$1');
+                        const link = decodeURIComponent(i.href.replaceAll('https://disq.us/url?url=', '')).replace(/(.*):.+cuid=.*/, '$1');
 
                         i.href = link;
                         i.innerHTML = link;
@@ -552,7 +552,7 @@ function DisqusJS(config) {
                  * @param {string} str - 字符串
                  * @return {string} - 替换后的字符串
                  */
-                const replaceDisquscdn = (str) => str.replace('/a.disquscdn.com/ig', 'c.disquscdn.com');
+                const replaceDisquscdn = (str) => str.replaceAll('a.disquscdn.com', 'c.disquscdn.com');
 
                 const renderPostItem = (s) => {
                     let authorEl = '';


### PR DESCRIPTION
`replaceDisquscdn` is supposed to be a regex, but it is a string. By using `String.prototype.replaceAll` we can keep the string 😁

Also fixed some typo (and switch another line to `replaceAll`).