### PR TITLE
如果 identifier 没有配置，那么使用 url 查询评论

### DIFF
--- a/src/disqus.js
+++ b/src/disqus.js
@@ -241,12 +241,14 @@ function DisqusJS(config) {
 
             /*
              * 获取 Thread 信息
-             * Disqus API 只支持通过 Thread ID 获取评论列表，所以必须先通过 identifier 获取当前页面 Thread ID
+             * Disqus API 只支持通过 Thread ID 获取评论列表，所以必须先通过 identifier 或 url 获取当前页面 Thread ID
              *
              * API Docs: https://disqus.com/api/docs/threads/list/
              * API URI: /3.0/threads/list.json?forum=[disqus_shortname]&thread=ident:[identifier]&api_key=[apikey]
              */
-            const url = `${disqusjs.config.api}3.0/threads/list.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(`ident:${disqusjs.config.identifier}`)}&api_key=${encodeURIComponent(apikey())}`;
+            const url = `${disqusjs.config.api}3.0/threads/list.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=` +
+                  encodeURIComponent(disqusjs.config.identifier ? `ident:${disqusjs.config.identifier}` : `link:${disqusjs.config.url}`) +
+                  `&api_key=${encodeURIComponent(apikey())}`;
 
             _get(url).then(({ data }) => {
                 if (data.code === 0 && data.response.length === 1) {

--- a/src/disqus.js
+++ b/src/disqus.js
@@ -330,9 +330,6 @@ function DisqusJS(config) {
                     getComment();
                 }
 
-                // 处理传入的 cursor
-                const cursorParam = (cursor === '') ? '' : `&cursor=${cursor}`;
-
                 // 在发起请求前禁用 加载更多评论 按钮防止重复调用
                 $loadMoreBtn.classList.add('dsqjs-disabled');
                 /*
@@ -366,7 +363,9 @@ function DisqusJS(config) {
                     }
                 };
 
-                const url = `${disqusjs.config.api}3.0/threads/listPosts.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}${encodeURIComponent(cursorParam)}&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
+                const url = `${disqusjs.config.api}3.0/threads/listPosts.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}` +
+                      (cursor === '' ? '' : `&cursor=${encodeURIComponent(cursor)}`) +
+                      `&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
 
                 _get(url).then(({ data }) => {
                     if (data.code === 0 && data.response.length > 0) {

--- a/src/disqus.js
+++ b/src/disqus.js
@@ -366,7 +366,7 @@ function DisqusJS(config) {
                     }
                 };
 
-                const url = `${disqusjs.config.api}3.0/threads/listPostsThreaded?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}${encodeURIComponent(cursorParam)}&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
+                const url = `${disqusjs.config.api}3.0/forums/listThreads.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}${encodeURIComponent(cursorParam)}&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
 
                 _get(url).then(({ data }) => {
                     if (data.code === 0 && data.response.length > 0) {

--- a/src/disqus.js
+++ b/src/disqus.js
@@ -366,7 +366,7 @@ function DisqusJS(config) {
                     }
                 };
 
-                const url = `${disqusjs.config.api}3.0/forums/listThreads.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}${encodeURIComponent(cursorParam)}&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
+                const url = `${disqusjs.config.api}3.0/threads/listPosts.json?forum=${encodeURIComponent(disqusjs.config.shortname)}&thread=${encodeURIComponent(disqusjs.page.id)}${encodeURIComponent(cursorParam)}&api_key=${encodeURIComponent(apikey())}&order=${encodeURIComponent(disqusjs.sortType)}`;
 
                 _get(url).then(({ data }) => {
                     if (data.code === 0 && data.response.length > 0) {


### PR DESCRIPTION
如题。我通常不配置 Disqus 的 `identifier`，所以希望可以用 `url` 查询。谢谢！

参见文档：https://disqus.com/api/docs/threads/list/