### PR TITLE
chore: switch 'rollup-plugin-bundle-analyzer' to 'vite-bundle-analyzer' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "react-refresh": "^0.9.0",
     "rimraf": "^5.0.5",
     "rollup": "^4.4.0",
-    "rollup-plugin-bundle-analyzer": "^1.6.6",
     "rollup-plugin-commonjs-alternate": "^0.8.0",
     "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-hot-css": "^0.7.2",
@@ -130,7 +129,8 @@
     "rollup-plugin-react-refresh": "^0.0.3",
     "rollup-plugin-static-files": "^0.2.0",
     "rollup-plugin-swc3": "^0.10.3",
-    "sass": "^1.69.5"
+    "sass": "^1.69.5",
+    "vite-bundle-analyzer": "^0.9.0"
   },
   "peerDependencies": {
     "preact": "^10.7.1",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -5,7 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import alias from '@rollup/plugin-alias';
 import { dts } from 'rollup-plugin-dts';
-import bundleAnalyzer from 'rollup-plugin-bundle-analyzer';
+import { adapter, analyzer } from 'vite-bundle-analyzer';
 
 import type { RollupCache, RollupOptions } from 'rollup';
 import type { JscTarget } from '@swc/core';
@@ -100,15 +100,16 @@ const outputMatrix = (config: {
             externalHelpers: true,
             target: config.target,
             minify: config.minify
-              ? { compress: { unsafe: true }, mangle: true, module: true }
+              ? { compress: { unsafe: true }, mangle: true, module: true, sourceMap: true }
               : undefined
           },
           minify: config.minify,
+          sourceMaps: true,
           module: {
             type: 'es6'
           }
         })),
-        process.env.ANALYZE === 'true' && bundleAnalyzer({})
+        process.env.ANALYZE === 'true' && adapter(analyzer())
       ],
       external: config.bundle
         ? undefined


### PR DESCRIPTION
# Background

`vite-bundle-analyzer` is more powerful and the behavior is similar with `webpack-bundle-analyzer` and it can reduce your `node_modules` size.

<img width="1468" alt="image" src="https://github.com/SukkaW/DisqusJS/assets/52351095/768db392-43af-4a1c-80e2-c129c63287db">

<img width="1066" alt="image" src="https://github.com/SukkaW/DisqusJS/assets/52351095/00dd0f71-f7b6-452e-9adf-812ba78674e9">

<img width="1032" alt="image" src="https://github.com/SukkaW/DisqusJS/assets/52351095/7983ac78-a320-424a-86b6-413de4ec5544">

